### PR TITLE
Add DCMAKE_BUILD_TYPE key in OSX and Linux generation scripts

### DIFF
--- a/generate-mac-shared.sh
+++ b/generate-mac-shared.sh
@@ -6,6 +6,6 @@ rm -rf ./build
 mkdir build
 cd build
 
-cmake .. -DOpenCL_INCLUDE_DIR="../../../../../Thirdparty/OpenCL-Headers" -DAMF_CORE_SHARED="true"
+cmake .. -DCMAKE_BUILD_TYPE=$1 -DOpenCL_INCLUDE_DIR="../../../../../Thirdparty/OpenCL-Headers" -DAMF_CORE_SHARED="true"
 
 cd ..

--- a/generate-mac-static.sh
+++ b/generate-mac-static.sh
@@ -6,6 +6,6 @@ rm -rf ./build
 mkdir build
 cd build
 
-cmake .. -DOpenCL_INCLUDE_DIR="../../../../../Thirdparty/OpenCL-Headers" -DAMF_CORE_STATIC="true"
+cmake .. -DCMAKE_BUILD_TYPE=$1 -DOpenCL_INCLUDE_DIR="../../../../../Thirdparty/OpenCL-Headers" -DAMF_CORE_STATIC="true"
 
 cd ..

--- a/generate-shared-linux.sh
+++ b/generate-shared-linux.sh
@@ -4,5 +4,5 @@ rm -rf ./linux
 mkdir linux
 
 cd linux
-cmake .. -DOpenCL_INCLUDE_DIR="../../../../../Thirdparty/OpenCL-Headers" -DAMF_CORE_SHARED=1
+cmake .. -DCMAKE_BUILD_TYPE=$1 -DOpenCL_INCLUDE_DIR="../../../../../Thirdparty/OpenCL-Headers" -DAMF_CORE_SHARED=1
 cd ..

--- a/generate-static-linux.sh
+++ b/generate-static-linux.sh
@@ -4,5 +4,5 @@ rm -rf ./linux
 mkdir linux
 
 cd linux
-cmake .. -DOpenCL_INCLUDE_DIR="../../../../../Thirdparty/OpenCL-Headers" -DAMF_CORE_STATIC=1
+cmake .. -DCMAKE_BUILD_TYPE=$1 -DOpenCL_INCLUDE_DIR="../../../../../Thirdparty/OpenCL-Headers" -DAMF_CORE_STATIC=1
 cd ..


### PR DESCRIPTION
### Purpose
* Add DCMAKE_BUILD_TYPE key in OSX and Linux generation scripts for specify build configuration